### PR TITLE
Array support (Performance warning in description)

### DIFF
--- a/Plugins/UnityWeakReferences/Editor/EditorUnityWeakReference.cs
+++ b/Plugins/UnityWeakReferences/Editor/EditorUnityWeakReference.cs
@@ -138,7 +138,8 @@ public sealed class EditorUnityWeakReference : IPreprocessBuildWithReport, IPost
 					for(int i = 0; i < itr.arraySize; i++)
                     			{
 						var element = itr.GetArrayElementAtIndex(i);
-						DoWork(element.serializedObject.targetObject, assetsToReference, validTypes);
+						if(element != null && element.serializedObject != null)
+							DoWork(element.serializedObject.targetObject, assetsToReference, validTypes);
 					}
 				}
 			}

--- a/Plugins/UnityWeakReferences/Editor/EditorUnityWeakReference.cs
+++ b/Plugins/UnityWeakReferences/Editor/EditorUnityWeakReference.cs
@@ -113,22 +113,34 @@ public sealed class EditorUnityWeakReference : IPreprocessBuildWithReport, IPost
 		var itr = so.GetIterator();
 		while (itr.NextVisible(true))
 		{
-			if (itr.propertyType == SerializedPropertyType.Generic && !itr.isArray && validTypes.ContainsKey(itr.type))
+			if (itr.propertyType == SerializedPropertyType.Generic && validTypes.ContainsKey(itr.type))
 			{
-				var pref = itr.FindPropertyRelative("reference");
-				var ppath = itr.FindPropertyRelative("path");
-				var pgo = pref.objectReferenceValue;
+				if(!itr.isArray)
+                		{
+					var pref = itr.FindPropertyRelative("reference");
+					var pgo = pref.objectReferenceValue;
 
-				if (pgo == null)
-					continue;
+					if (pgo == null)
+						continue;
 
-				var path = AssetDatabase.GetAssetPath(pgo);
-				var guid = AssetDatabase.AssetPathToGUID(path);
+					var pt = validTypes[itr.type];
 
-				var pt = validTypes[itr.type];
+					var path = AssetDatabase.GetAssetPath(pgo);
+					var guid = AssetDatabase.AssetPathToGUID(path);
 
-				if (!assetsToReference.ContainsKey(guid))
-					assetsToReference.Add(guid, new AssetInfo { GUID = guid, Path = path, WeakPath = ppath.stringValue, Type = pt });
+					if (!assetsToReference.ContainsKey(guid))
+						assetsToReference.Add(guid, new AssetInfo { GUID = guid, Type = pt, Path = path });
+				}
+				else
+                		{
+					// drill down into arrays
+					for(int i = 0; i < itr.arraySize; i++)
+                    			{
+						var element = itr.GetArrayElementAtIndex(i);
+						if (element.propertyType == SerializedPropertyType.Generic && validTypes.ContainsKey(element.type))
+							DoWork(element.serializedObject.targetObject, assetsToReference, validTypes);
+					}		
+                		}
 			}
 		}
 	}

--- a/Plugins/UnityWeakReferences/Editor/EditorUnityWeakReference.cs
+++ b/Plugins/UnityWeakReferences/Editor/EditorUnityWeakReference.cs
@@ -113,22 +113,34 @@ public sealed class EditorUnityWeakReference : IPreprocessBuildWithReport, IPost
 		var itr = so.GetIterator();
 		while (itr.NextVisible(true))
 		{
-			if (itr.propertyType == SerializedPropertyType.Generic && !itr.isArray && validTypes.ContainsKey(itr.type))
+			if (itr.propertyType == SerializedPropertyType.Generic && validTypes.ContainsKey(itr.type))
 			{
-				var pref = itr.FindPropertyRelative("reference");
-				var ppath = itr.FindPropertyRelative("path");
-				var pgo = pref.objectReferenceValue;
+				if(!itr.isArray)
+               			{
+					var pref = itr.FindPropertyRelative("reference");
+					var ppath = itr.FindPropertyRelative("path");
+					var pgo = pref.objectReferenceValue;
 
-				if (pgo == null)
-					continue;
+					if (pgo == null)
+						continue;
 
-				var path = AssetDatabase.GetAssetPath(pgo);
-				var guid = AssetDatabase.AssetPathToGUID(path);
+					var path = AssetDatabase.GetAssetPath(pgo);
+					var guid = AssetDatabase.AssetPathToGUID(path);
 
-				var pt = validTypes[itr.type];
+					var pt = validTypes[itr.type];
 
-				if (!assetsToReference.ContainsKey(guid))
-					assetsToReference.Add(guid, new AssetInfo { GUID = guid, Path = path, WeakPath = ppath.stringValue, Type = pt });
+					if (!assetsToReference.ContainsKey(guid))
+						assetsToReference.Add(guid, new AssetInfo { GUID = guid, Path = path, WeakPath = ppath.stringValue, Type = pt });
+				}
+				else
+				{
+					// drill down into arrays
+					for(int i = 0; i < itr.arraySize; i++)
+                    			{
+						var element = itr.GetArrayElementAtIndex(i);
+						DoWork(element.serializedObject.targetObject, assetsToReference, validTypes);
+					}
+				}
 			}
 		}
 	}

--- a/Plugins/UnityWeakReferences/Editor/EditorUnityWeakReference.cs
+++ b/Plugins/UnityWeakReferences/Editor/EditorUnityWeakReference.cs
@@ -113,34 +113,22 @@ public sealed class EditorUnityWeakReference : IPreprocessBuildWithReport, IPost
 		var itr = so.GetIterator();
 		while (itr.NextVisible(true))
 		{
-			if (itr.propertyType == SerializedPropertyType.Generic && validTypes.ContainsKey(itr.type))
+			if (itr.propertyType == SerializedPropertyType.Generic && !itr.isArray && validTypes.ContainsKey(itr.type))
 			{
-				if(!itr.isArray)
-                		{
-					var pref = itr.FindPropertyRelative("reference");
-					var pgo = pref.objectReferenceValue;
+				var pref = itr.FindPropertyRelative("reference");
+				var ppath = itr.FindPropertyRelative("path");
+				var pgo = pref.objectReferenceValue;
 
-					if (pgo == null)
-						continue;
+				if (pgo == null)
+					continue;
 
-					var pt = validTypes[itr.type];
+				var path = AssetDatabase.GetAssetPath(pgo);
+				var guid = AssetDatabase.AssetPathToGUID(path);
 
-					var path = AssetDatabase.GetAssetPath(pgo);
-					var guid = AssetDatabase.AssetPathToGUID(path);
+				var pt = validTypes[itr.type];
 
-					if (!assetsToReference.ContainsKey(guid))
-						assetsToReference.Add(guid, new AssetInfo { GUID = guid, Type = pt, Path = path });
-				}
-				else
-                		{
-					// drill down into arrays
-					for(int i = 0; i < itr.arraySize; i++)
-                    			{
-						var element = itr.GetArrayElementAtIndex(i);
-						if (element.propertyType == SerializedPropertyType.Generic && validTypes.ContainsKey(element.type))
-							DoWork(element.serializedObject.targetObject, assetsToReference, validTypes);
-					}		
-                		}
+				if (!assetsToReference.ContainsKey(guid))
+					assetsToReference.Add(guid, new AssetInfo { GUID = guid, Path = path, WeakPath = ppath.stringValue, Type = pt });
 			}
 		}
 	}


### PR DESCRIPTION
Drill down into array types to find WeakReferences.

Warning this may explode your build performance if you don't add support to filter types. Worth comparing with larger project before deploying.